### PR TITLE
Working with duplicate kinetics within a single PLOG

### DIFF
--- a/rmgpy/kinetics/arrhenius.pyx
+++ b/rmgpy/kinetics/arrhenius.pyx
@@ -408,7 +408,6 @@ cdef class PDepArrhenius(PDepKineticsModel):
         Returns the pressures and Arrhenius expressions for the pressures that
         most closely bound the specified pressure `P` in Pa.
         """
-        cdef Arrhenius arrh
         cdef numpy.ndarray[numpy.float64_t,ndim=1] pressures
         cdef int i, ilow, ihigh
         
@@ -428,7 +427,7 @@ cdef class PDepArrhenius(PDepKineticsModel):
         mol, and s at temperature `T` in K and pressure `P` in Pa.
         """
         cdef double Plow, Phigh, klow, khigh, k
-        cdef Arrhenius alow, ahigh
+        cdef KineticsModel alow, ahigh
         cdef int j
         
         if P == 0:
@@ -650,7 +649,7 @@ cdef class MultiPDepArrhenius(PDepKineticsModel):
         """
         cdef double k, klow, khigh, Plow, Phigh
         cdef PDepArrhenius arrh
-        cdef Arrhenius arrh_low, arrh_high
+        cdef KineticsModel arrh_low, arrh_high
         cdef numpy.ndarray Plist1, Plist2
         cdef int i
         


### PR DESCRIPTION
These commits hope to address issue https://github.com/GreenGroup/RMG-Py/issues/147, where PLOGs in this format are interpreted incorrectly:

    C3H6(48)+HO2(9)=OH(5)+C3H6O(70)                     1.000e+00 0.000     0.000    
    PLOG/ 0.010     4.720e+04 2.290     12.336   /
    PLOG/ 0.010     1.090e+05 2.180     12.535   /
    PLOG/ 1.000     4.660e+07 1.420     14.066   /
    PLOG/ 10.000    1.930e+12 0.107     17.385   /
    PLOG/ 100.000   1.300e+11 0.544     19.059   / 

I've made the PDepArrhenius and MultiPDepArrhenius classes allow MultiArrhenius objects in their arrhenius list of objects.  That way khigh and klow can be determined from a duplicate reaction MultiArrhenius object at a single pressure.

I've altered the chemkin reading and writing by storing the PLOG kinetics with MultiArrhenius objects when there are duplicate kinetics at a single pressure, but rewriting to chemkin as two lines of PLOGS at a single pressure.

I've tested it by creating a kinetics library from a chemkin file- it works and creates the correct PDepArrhenius object.  I think the chemkin read and write also works.

One problem that might occur is if the pressures in the PLOG are slightly off, as in if one is 0.01 and another pressure is 0.01001.  Should we combine those kinetics?  For now I ignore that and only do an identical P1 == P2 check.