### PR TITLE
Also mark duplicate reactions in the reverse direction for chemkin files

### DIFF
--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1575,7 +1575,8 @@ def markDuplicateReaction(test_reaction, reaction_list):
             # duplicates of one another.
             # RHW question: why can't TemplateReaction be duplicate of LibraryReaction, in Chemkin terms? I guess it shouldn't happen in RMG.
             continue
-        if reaction1.reactants == reaction2.reactants and reaction1.products == reaction2.products:
+        if (reaction1.reactants == reaction2.reactants and reaction1.products == reaction2.products) \
+        or (reaction1.products == reaction2.reactants and reaction1.reactants == reaction2.products):
             if reaction1.duplicate and reaction2.duplicate:
                 continue
             else:

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -34,6 +34,7 @@ This module contains functions for writing of Chemkin input files.
 import math
 import re
 import logging
+import textwrap
 import os.path
 import numpy
 import kinetics as _kinetics
@@ -1301,7 +1302,12 @@ def writeThermoEntry(species, verbose = True):
     if verbose:
         if thermo.comment:
             for line in thermo.comment.split("\n"):
-                string += "! {0}\n".format(line) 
+                if len(line) > 150:
+                    short_lines = textwrap.fill(line,150).split("\n")
+                    for short_line in short_lines:
+                        string += "! {0}\n".format(short_line) 
+                else:
+                    string += "! {0}\n".format(line) 
 
     # Line 1
     string += '{0:<16}        '.format(getSpeciesIdentifier(species))
@@ -1456,7 +1462,12 @@ def writeKineticsEntry(reaction, speciesList, verbose = True, javaLibrary = Fals
         # Remaining lines of comments taken from reaction kinetics
         if reaction.kinetics.comment:
             for line in reaction.kinetics.comment.split("\n"):
-                string += "! {0}\n".format(line)                               
+                if len(line) > 150:
+                    short_lines = textwrap.fill(line,150).split("\n")
+                    for short_line in short_lines:
+                        string += "! {0}\n".format(short_line) 
+                else:
+                    string += "! {0}\n".format(line)                               
     
     kinetics = reaction.kinetics
     numReactants = len(reaction.reactants)

--- a/rmgpy/chemkin.py
+++ b/rmgpy/chemkin.py
@@ -1588,8 +1588,11 @@ def markDuplicateReaction(test_reaction, reaction_list):
             continue
         if (reaction1.reactants == reaction2.reactants and reaction1.products == reaction2.products) \
         or (reaction1.products == reaction2.reactants and reaction1.reactants == reaction2.products):
-            if reaction1.duplicate and reaction2.duplicate:
-                continue
+            if reaction1.duplicate and reaction2.duplicate:                
+                if reaction1.kinetics.isPressureDependent() != reaction2.kinetics.isPressureDependent():
+                    logging.warning('Marked reaction {0} as not duplicate because of mixed pressure dependence for saving to Chemkin file.'.format(reaction1))
+                    reaction1.duplicate = False
+                    reaction2.duplicate = False
             else:
                 if reaction1.kinetics.isPressureDependent() == reaction2.kinetics.isPressureDependent():
                     # Only mark as duplicate if both reactions are pressure dependent or both are


### PR DESCRIPTION
With the latest commits to RMG, the behavior of treating reaction libraries is a bit different now.  We have made it possible to be more flexible with regards to duplicate reactions.  All duplicate reactions, be it mixed Pdep and nonPdep, reverse or forward directions, MUST be marked duplicate within the kinetic library.  RMG performs a check on loading the library to check this and will throw an error if they are unmarked.  We do not enforce the MultiArrhenius or MultiPDepArrhenius rule for this.  Sometimes people want to have a Pdep and Non-Pdep reaction together.  Maybe they want 2 TROE reactions together, or whatever combination.  I think it should be allowed.

When using multiple libraries, the duplicate checking is in done between libraries and also for template reactions against libraries (in both directions) in this section of code: https://github.com/GreenGroup/RMG-Py/blob/master/rmgpy/rmg/model.py#L495

In terms of duplicate reactions printing in CHEMKIN, here is where it gets a little tricky.  This is the summary of behavior that CHEMKIN accepts:

2 Non-Pdep Reactions:
Must be marked duplicate (including in reversed directions) https://github.com/connie/RMG-Py/commit/94420b6c1832005e1ef880148454123bcd3676ac fixes it for reversed reactions

2 Pdep Reactions:
Must be marked duplicate  (including in reversed directions)

1 Pdep and 1 Non-pdep reaction
Should not be marked duplicate, or else CHEMKIN throws an error.  https://github.com/connie/RMG-Py/commit/818e64a4b5ab54521365bb2b6b0459c40680e672

One thing that might be not robust in the code is when you have multiple duplicate reactions of mixed pdep behavior... it will definitely lead to incorrect tagging.

We currently allow duplicate reactions that come from different families, but not within the same family but with different transition states..  This is something that needs to be fixed- see https://github.com/GreenGroup/RMG-Py/pull/323.

Should fix https://github.com/GreenGroup/RMG-Py/issues/335 and https://github.com/GreenGroup/RMG-Py/issues/333 and https://github.com/GreenGroup/RMG-Py/issues/146.