### PR TITLE
Added documentation for making RMG inp files, small cantherm fixup

### DIFF
--- a/documentation/source/theory/rmg/prune.rst
+++ b/documentation/source/theory/rmg/prune.rst
@@ -14,11 +14,11 @@ Key Parameters in Pruning
 
 * toleranceKeepInEdge
 
-  Any edge species to prune should have peak flux along the whole conversion course lower than toleranceKeepInEdge :math:`*` characteristic flux.
+  Any edge species to prune should have peak flux along the whole conversion course lower than toleranceKeepInEdge :math:`*` characteristic flux. Thus, larger values will lead to larger edge mechanisms.
 
 * toleranceMoveToCore
 
-  Any edge species to enter core model should have flux at some point larger than toleranceKeepInEdge :math:`*` characteristic flux
+  Any edge species to enter core model should have flux at some point larger than toleranceMoveToCore :math:`*` characteristic flux Thus, in general, smaller values will lead to larger core mechanisms.
 
 * toleranceInterrupSimulation
 

--- a/documentation/source/users/rmg/input.rst
+++ b/documentation/source/users/rmg/input.rst
@@ -411,6 +411,8 @@ The following is an example of pressure dependence options ::
 		maximumAtoms=16,
 	)
 
+Regarding the number of polynomial coeffients for Chebyshev interpolated rates, plese refer to the :ref:`documentation <rmgpy.kinetics.Chebyshev>`. The number of pressures and temperature coefficents should always be smaller than the respective number of user-specified temperatures and pressures. 
+
 Miscellaneous Options
 ===================== 
 
@@ -419,9 +421,14 @@ Miscellaneous options::
     options(
         units='si',
         saveRestartPeriod=(1,'hour'),
-        drawMolecules=False,
+        drawMolecules=True,
         generatePlots=False,
     )
+
+Setting `drawMolecules=True` will let RMG know that you want to save 2-D images (png files in the local `species` folder) of all species in the generated core model. This feature is recommended if you wish to easily view the species and reactions in the html file that accompanies an RMG job. Otherwise, the user will be forced to decifer SMILES strings. Also note that if `drawMolecules=False`, but the user specifies a `pressureDependence` section of the input file, RMG will still generate species files in the `species` folder, but only those that pertain to pressure dependent networks that RMG discovers. 
+
+The `saveRestartPeriod` indictes how frequently you wish to save restart files. For very large/long RMG jobs, this process can take a significant amount of time. In such cases, the user may wish to increase the time period for restart.
+
     
 Species Constraints
 ===================== 

--- a/rmgpy/pdep/network.py
+++ b/rmgpy/pdep/network.py
@@ -202,7 +202,7 @@ class Network:
                 logging.debug('Using ILT method to compute k(E) for path reaction {0}.'.format(rxn))
         logging.debug('')
         
-        logging.info('Calculating phenomenological rate coefficients for {0}...'.format(self))
+        logging.info('Calculating phenomenological rate coefficients for {0}...'.format(rxn))
         K = numpy.zeros((len(Tlist),len(Plist),Nisom+Nreac+Nprod,Nisom+Nreac+Nprod), numpy.float64)
         
         for t, T in enumerate(Tlist):


### PR DESCRIPTION
Changed `drawMolecules=False` to `True` in the doc and added an explanation
for why a user would want this. Also, small fixup in cantherm's code that now lets users know which reaction RRKM rates are being calculated for.