### PR TITLE
Fix to add labels to libraries in loadOld

### DIFF
--- a/rmgpy/data/kinetics/library.py
+++ b/rmgpy/data/kinetics/library.py
@@ -336,6 +336,7 @@ class KineticsLibrary(Database):
                 index = index+1,
                 item = reaction,
                 data = reaction.kinetics,
+                label = str(reaction)
             )
             entry.longDesc = reaction.kinetics.comment
             reaction.kinetics.comment = ''


### PR DESCRIPTION
Previously we listed the adjlist for all reactants and products in the
entry for the reaction. A recent change now has a separate dictionary file
and reaction files, so that reactants can be editted once instead of once
for every reaction they are in.

However, now we need to add a label property to each reaction entry to
substitute for the the adjList. This fix adds one line which adds the
correct label (hopefully in all cases)