### PR TITLE
Fix to solvation thermo for lone pairs

### DIFF
--- a/documentation/source/users/rmg/liquids.rst
+++ b/documentation/source/users/rmg/liquids.rst
@@ -108,7 +108,7 @@ dipole interactions related to the polarizability of the solvent) [Vitha2006]_, 
 `lL` term accounts for the contribution from cavity formation and dispersion (dispersion interactions are 
 known to scale with solute volume [Vitha2006]_, [Abraham1999]_. The `eE` term, like the `sS` term, 
 accounts for residual contributions from dipolarity/polarizability related interactions for solutes 
-whose blend of dipolarity/polarizability differs from that implicitly built into the `S` parameter [Vitha2006]_, [Abraham1990]_, [Jalan2010]_. 
+whose blend of dipolarity/polarizability differs from that implicitly built into the `S` parameter [Vitha2006]_, [Abraham1999]_, [Jalan2010]_. 
 The `aA` and `bB` terms account for the contribution of hydrogen bonding between the solute and 
 the surrounding solvent molecules. H-bonding interactions require two terms as the solute (or solvent) 
 can act as acceptor (donor) and vice versa. The descriptor `A` is a measure of the solute's ability 
@@ -249,18 +249,30 @@ This is an example of an input file for a liquid-phase system::
         saveSimulationProfiles=True,
     )
 
-.. [Vitha2006] \ Vitha2006
-.. [Abrham1999] \ Abraham1999
-.. [Jalan2010] \ Jalan2010
-.. [Poole2009] \ Poole2009
-.. [Platts1999] \ Platts1999
-.. [Mintz2007] \ Mintz2007
-.. [Mintz2007a] \ Mintz2007a
-.. [Mintz2007b] \ Mintz2007b
-.. [Mintz2007c] \ Mintz2007c
-.. [Mintz2007d] \ Mintz2007d
-.. [Mintz2008] \ Mintz2008
-.. [Mintz2008a] \ Mintz2008a
-.. [Mintz2009] \ Mintz2009
-.. [Rice1985] \ Rice1985
+.. [Vitha2006] \ M. Vitha and P.W. Carr. "The chemical interpretation and practice of linear solvation energy relationships in chromatography." *J. Chromatogr. A.* **1126(1-2)**, p. 143-194 (2006).
 
+.. [Abraham1999] \ M.H. Abraham et al. "Correlation and estimation of gas-chloroform and water-chloroformpartition coefficients by a linear free energy relationship method." *J. Pharm. Sci.* **88(7)**, p. 670-679 (1999).
+
+.. [Jalan2010] \ A. Jalan et al. "Predicting solvation energies for kinetic modeling." *Annu. Rep.Prog. Chem., Sect. C* **106**, p. 211-258 (2010).
+
+.. [Poole2009] \ C.F. Poole et al. "Determination of solute descriptors by chromatographic methods." *Anal. Chim. Acta* **652(1-2)** p. 32-53 (2009).
+
+.. [Platts1999] \ J. Platts and D. Butina. "Estimation of molecular linear free energy relation descriptorsusing a group contribution approach." *J. Chem. Inf. Comput. Sci.* **39**, p. 835-845 (1999).
+
+.. [Mintz2007] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved inwater and in 1-octanol based on the Abraham model." *J. Chem. Inf. Model.* **47(1)**, p. 115-121 (2007).
+
+.. [Mintz2007a] \ C. Mintz et al. "Enthalpy of solvation corrections for gaseous solutes dissolved in benzene and in alkane solvents based on the Abraham model." *QSAR Comb. Sci.* **26(8)**, p. 881-888 (2007).
+
+.. [Mintz2007b] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved in toluene and carbon tetrachloride based on the Abraham model." *J. Sol. Chem.* **36(8)**, p. 947-966 (2007).
+
+.. [Mintz2007c] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved indimethyl sulfoxide and propylene carbonate based on the Abraham model." *Thermochim. Acta* **459(1-2)**, p, 17-25 (2007).
+
+.. [Mintz2007d] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved inchloroform and 1,2-dichloroethane based on the Abraham model." *Fluid Phase Equilib.* **258(2)**, p. 191-198 (2007).
+
+.. [Mintz2008] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved inlinear alkanes (C5-C16) based on the Abraham model." *QSAR Comb. Sci.* **27(2)**, p. 179-186 (2008).
+
+.. [Mintz2008a] \ C. Mintz et al. "Enthalpy of solvation correlations for gaseous solutes dissolved inalcohol solvents based on the Abraham model." *QSAR Comb. Sci.* **27(5)**, p. 627-635 (2008).
+
+.. [Mintz2009] \ C. Mintz et al. "Enthalpy of solvation correlations for organic solutes and gasesdissolved in acetonitrile and acetone." *Thermochim. Acta* **484(1-2)**, p. 65-69 (2009).
+
+.. [Rice1985] \ S.A. Rice. "Diffusion-limited reactions". In *Comprehensive Chemical Kinetics*, EditorsC.H. Bamford, C.F.H. Tipper and R.G. Compton. **25**, (1985).

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -77,12 +77,7 @@ class TestSoluteDatabase(TestCase):
         "Test we can estimate Abraham solute parameters correctly using group contributions"
         
         self.testCases = [
-        # from RMG-Java test runs by RWest (mostly in agreement with Jalan et. al. supplementary data)
         ['1,2-ethanediol', 'C(CO)O', 0.823, 0.685, 0.327, 2.572, 0.693, None],
-        # a nitrogen case
-        #['acetonitrile', 'CC#N', 0.9, 0.33, 0.237, 1.739, 0.04, None],
-        # a sulfur case
-        #['ethanethiol', 'CCS', 0.35, 0.24, 0.392, 2.173, 0, None]
         ]
         
         for name, smiles, S, B, E, L, A, V in self.testCases:
@@ -93,6 +88,37 @@ class TestSoluteDatabase(TestCase):
             self.assertAlmostEqual(soluteData.E, E, places=2)
             self.assertAlmostEqual(soluteData.L, L, places=2)
             self.assertAlmostEqual(soluteData.A, A, places=2)
+
+    def testLonePairSoluteGeneration(self):
+        "Test we can obtain solute parameters via group additivity for a molecule with lone pairs"
+        molecule=Molecule().fromAdjacencyList(
+"""
+CH2_singlet
+multiplicity 1
+1 C u0 p1 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""")
+        species = Species(molecule=[molecule])
+	soluteData = self.database.getSoluteDataFromGroups(species)
+        self.assertTrue(soluteData is not None)
+
+    def testRadicalandLonePairGeneration(self):
+        """
+        Test we can obtain solute parameters via group additivity for a molecule with both lone 
+        pairs and a radical
+        """
+        molecule=Molecule().fromAdjacencyList(
+"""
+[C]OH
+multiplicity 2
+1 C u1 p1 c0 {2,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 H u0 p0 c0 {2,S}
+""")
+        species = Species(molecule=[molecule])
+	soluteData = self.database.getSoluteDataFromGroups(species)
+        self.assertTrue(soluteData is not None)
 
     def testCorrectionGeneration(self):
         "Test we can estimate solvation thermochemistry."

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -116,7 +116,25 @@ multiplicity 1
         species = Species(molecule=[molecule])
         soluteData = self.database.getSoluteDataFromGroups(species)
         self.assertTrue(soluteData is not None)
-
+        
+    def testSoluteDataGenerationAmide(self):
+        "Test that we can obtain solute parameters via group additivity for an amide"        
+        molecule=Molecule().fromAdjacencyList(
+"""
+1  N u0 p1 {2,S} {3,S} {4,S}
+2   H   u0 {1,S}
+3   C u0 {1,S} {6,S} {7,S} {8,S}
+4   C  u0 {1,S} {5,D} {9,S}
+5   O  u0 p2 {4,D}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+9   H   u0 {4,S}
+""")
+        species = Species(molecule=[molecule])
+        soluteData = self.database.getSoluteDataFromGroups(species)
+        self.assertTrue(soluteData is not None)
+        
     def testRadicalandLonePairGeneration(self):
         """
         Test we can obtain solute parameters via group additivity for a molecule with both lone 

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -103,7 +103,6 @@ multiplicity 1
         soluteData = self.database.getSoluteDataFromGroups(species)
         self.assertTrue(soluteData is not None)
         
-    @work_in_progress
     def testSoluteDataGenerationAmmonia(self):
         "Test we can obtain solute parameters via group additivity for ammonia"
         molecule=Molecule().fromAdjacencyList(

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -100,7 +100,21 @@ multiplicity 1
 3 H u0 p0 c0 {1,S}
 """)
         species = Species(molecule=[molecule])
-	soluteData = self.database.getSoluteDataFromGroups(species)
+        soluteData = self.database.getSoluteDataFromGroups(species)
+        self.assertTrue(soluteData is not None)
+        
+    @work_in_progress
+    def testSoluteDataGenerationAmmonia(self):
+        "Test we can obtain solute parameters via group additivity for ammonia"
+        molecule=Molecule().fromAdjacencyList(
+"""
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""")
+        species = Species(molecule=[molecule])
+        soluteData = self.database.getSoluteDataFromGroups(species)
         self.assertTrue(soluteData is not None)
 
     def testRadicalandLonePairGeneration(self):
@@ -117,7 +131,7 @@ multiplicity 2
 3 H u0 p0 c0 {2,S}
 """)
         species = Species(molecule=[molecule])
-	soluteData = self.database.getSoluteDataFromGroups(species)
+        soluteData = self.database.getSoluteDataFromGroups(species)
         self.assertTrue(soluteData is not None)
 
     def testCorrectionGeneration(self):

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -688,7 +688,7 @@ class ThermoDatabase(object):
             if thermoData is not None:
                 assert len(thermoData) == 3, "thermoData should be a tuple at this point"
                 if rmgpy.rmg.main.solvent is not None and trainingSet is None:
-                    thermoData[0].comment += 'Thermo library "corrected": ' + label
+                    thermoData[0].comment += 'Thermo library corrected for liquid phase: ' + label
                 else:
                     thermoData[0].comment += 'Thermo library: ' + label
                 return thermoData


### PR DESCRIPTION
This addresses issue #342 .

When a lone pair is encountered, we turn it into two unpaired electrons for the purpose of adding hydrogens and looking up the solvation thermo of the saturated structure. But we only replace the lone pairs based on the usual valency of the atom. For example for CH2(S) we would replace that lone pair to make sum(unpaired electrons + bonds + charge) be equal to 4. But for H2O we wouldn't replace the lone pairs on Oxygen.

When we "unsaturate" the radicals, we should also correct the "A" H-bonding parameter that we previously calculated for the saturated structure. In the future we can have a radical solute library in the database, which "cancels" out the A value that we got from the molecule, as in RMG-Java. As a quick fix for right now, I am only correcting oxygen radicals, with a value of -0.345. 0.345 is the A value for -OH and -OOH. In the RMG-Java database, we have one additional entry for O in carboxylic acids; in RMG-Py, we will also need values for N and S radicals.

Also, an old fixup to the documentation that I never committed.