### PR TITLE
Fixing kinetics commenting and other minor bugs

### DIFF
--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1690,24 +1690,8 @@ class KineticsFamily(Database):
         """
         Determine the appropriate kinetics for a reaction with the given
         `template` using rate rules.
-        """
+        """    
         kinetics, entry  = self.rules.estimateKinetics(template, degeneracy)
-        if self.label.lower() == 'r_recombination':
-            # The kinetics could be stored exactly with the template labels swapped
-            # If this gives an exact match and the other gives an estimate, then keep the exact match
-            # Not sure how to decide which to keep if both are exact or both are estimates
-            kinetics0, entry0 = self.rules.estimateKinetics(template[::-1], degeneracy)
-            if entry0:
-                # Matched an exact entry in the other direction
-                if entry:
-                    if entry0.rank < entry.rank:
-                        # other direction has a higher (smaller valued) rank than original direction
-                        kinetics = kinetics0
-                        entry = entry0
-                else:
-                    # No exact match in original direction, so use the match from the other direction
-                    kinetics = kinetics0
-                    entry = entry0
                 
         return kinetics, entry
 

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1696,9 +1696,19 @@ class KineticsFamily(Database):
             # The kinetics could be stored exactly with the template labels swapped
             # If this gives an exact match and the other gives an estimate, then keep the exact match
             # Not sure how to decide which to keep if both are exact or both are estimates
-            kinetics0 = self.rules.estimateKinetics(template[::-1], degeneracy)
-            if 'exact' in kinetics0.comment.lower() and 'exact' not in kinetics.comment.lower():
-                kinetics = kinetics0
+            kinetics0, entry0 = self.rules.estimateKinetics(template[::-1], degeneracy)
+            if entry0:
+                # Matched an exact entry in the other direction
+                if entry:
+                    if entry0.rank < entry.rank:
+                        # other direction has a higher (smaller valued) rank than original direction
+                        kinetics = kinetics0
+                        entry = entry0
+                else:
+                    # No exact match in original direction, so use the match from the other direction
+                    kinetics = kinetics0
+                    entry = entry0
+                
         return kinetics, entry
 
     def getRateCoefficientUnits(self):

--- a/rmgpy/data/kinetics/family.py
+++ b/rmgpy/data/kinetics/family.py
@@ -1601,30 +1601,6 @@ class KineticsFamily(Database):
                 kinetics.comment += "Matched reaction {0} {1} in {2}".format(entry.index, entry.label, depository.label)
         return kineticsList
     
-    def getKineticsFromRules(self, template, degeneracy):
-        """
-        Search the given `depository` in this kinetics family for kinetics
-        for the given `reaction`. Returns a list of all of the matching 
-        kinetics, the corresponding entries, and ``True`` if the kinetics
-        match the forward direction or ``False`` if they match the reverse
-        direction.
-        """
-        kineticsList = []
-        
-        entries = self.rules.getAllRules(template)
-        for entry in entries:
-            kineticsList.append([deepcopy(entry.data), entry, True])
-        
-        for kinetics, entry, isForward in kineticsList:
-            if kinetics is not None:
-                # The rules are defined on a per-site basis, so we need to include the degeneracy manually
-                assert isinstance(kinetics, ArrheniusEP)
-                kinetics.A.value_si *= degeneracy
-                kinetics.comment += "Matched rule {0} {1} in {2}\n".format(entry.index, entry.label, self.rules.label)
-                kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
-        
-        return kineticsList
-    
     def __selectBestKinetics(self, kineticsList):
         """
         For a given set of kinetics `kineticsList`, return the kinetics deemed
@@ -1660,15 +1636,6 @@ class KineticsFamily(Database):
             else:
                 for kinetics, entry, isForward in kineticsList0:
                     kineticsList.append([kinetics, depository, entry, isForward])
-        
-        # Check the rate rules for kinetics
-        kineticsList0 = self.getKineticsFromRules(template, degeneracy)
-        if len(kineticsList0) > 0 and not returnAllKinetics:
-            kinetics, entry, isForward = self.__selectBestKinetics(kineticsList0)
-            return kinetics, self.rules, entry, isForward
-        else:
-            for kinetics, entry, isForward in kineticsList0:
-                kineticsList.append([kinetics, self.rules, entry, isForward])
         
         # If estimator type of rate rules or group additivity is given, retrieve the kinetics. 
         if estimator:        

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -437,9 +437,12 @@ class KineticsRules(Database):
             
             # We found one or more results! Let's average them together
             kinetics = self.__getAverageKinetics([k for k, t in kineticsList])
-            kinetics.comment += 'Average of ({0}). '.format(
-                ' + '.join([k.comment if k.comment != '' else ','.join([g.label for g in t]) for k, t in kineticsList]),
-            )
+            if len(kineticsList) > 1:
+                kinetics.comment += 'Average of ({0})'.format(
+                    ' + '.join(k.comment if k.comment != '' else ';'.join(g.label for g in t) for k, t in kineticsList))
+            else:
+                k,t = kineticsList[0]
+                kinetics.comment += k.comment if k.comment != '' else ';'.join(g.label for g in t)
             entry = Entry(
                 index = 0,
                 label = rootLabel,
@@ -523,7 +526,10 @@ class KineticsRules(Database):
                         kinetics.comment += 'Exact match found' 
                     else:
                     # Using a more general node to estimate original template
-                        kinetics.comment += 'Estimated using template ' + matchedLeaves
+                        if kinetics.comment:
+                            kinetics.comment += '\n'
+                        kinetics.comment +='Estimated using template ' + matchedLeaves
+                            
                 else:
                     # We found one or more results! Let's average them together
                     kinetics = self.__getAverageKinetics([k for k, t in kineticsList])

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -539,6 +539,8 @@ class KineticsRules(Database):
                 
                 kinetics.comment +=  ' for rate rule ' + originalLeaves
                 kinetics.A.value_si *= degeneracy
+                kinetics.comment += "\n"
+                kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
 
                 return kinetics
             

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -542,8 +542,9 @@ class KineticsRules(Database):
                 
                 kinetics.comment +=  ' for rate rule ' + originalLeaves
                 kinetics.A.value_si *= degeneracy
-                kinetics.comment += "\n"
-                kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
+                if degeneracy > 1:
+                    kinetics.comment += "\n"
+                    kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
 
                 return kinetics
             

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -523,7 +523,10 @@ class KineticsRules(Database):
                     # leaves) were found or not.
                     matchedLeaves = getTemplateLabel(t)
                     if matchedLeaves == originalLeaves:
-                        kinetics.comment += 'Exact match found' 
+                        if 'Average' in kinetics.comment:
+                            kinetics.comment += 'Estimated using an average'
+                        else:
+                            kinetics.comment += 'Exact match found' 
                     else:
                     # Using a more general node to estimate original template
                         if kinetics.comment:

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -546,7 +546,7 @@ class KineticsRules(Database):
                     kinetics.comment += "\n"
                     kinetics.comment += "Multiplied by reaction path degeneracy {0}".format(degeneracy)
 
-                return kinetics
+                return kinetics, entry if 'Exact' in kinetics.comment else None
             
             else:
                 # No results found

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -498,7 +498,7 @@ class KineticsRules(Database):
         """
         def getTemplateLabel(template):
             # Get string format of the template in the form "(leaf1,leaf2)"
-            return '({0})'.format(','.join([g.label for g in template]))
+            return '({0})'.format(';'.join([g.label for g in template]))
     
         
         originalLeaves = getTemplateLabel(template)

--- a/rmgpy/data/kinetics/rules.py
+++ b/rmgpy/data/kinetics/rules.py
@@ -378,7 +378,8 @@ class KineticsRules(Database):
         except KeyError:
             pass
         
-        if self.label.lower() == 'r_recombination' and template[0] != template[1]:
+        family = os.path.split(self.label)[0]   # i.e. self.label = 'R_Recombination/rules'
+        if family.lower() == 'r_recombination':
             template.reverse()
             templateLabels = ';'.join([group.label for group in template])
             try:

--- a/rmgpy/rmg/input.py
+++ b/rmgpy/rmg/input.py
@@ -58,7 +58,7 @@ def database(
              seedMechanisms = None,
              kineticsFamilies = 'default',
              kineticsDepositories = 'default',
-             kineticsEstimator = 'group additivity',
+             kineticsEstimator = 'rate rules',
              ):
     # This function just stores the information about the database to be loaded
     # We don't actually load the database until after we're finished reading

--- a/rmgpy/rmg/main.py
+++ b/rmgpy/rmg/main.py
@@ -415,16 +415,19 @@ class RMG:
                         pass
                     else:
                         raise ForbiddenStructureException("Species constraints forbids input species {0}. Please reformulate constraints, remove the species, or explicitly allow it.".format(spec.label))
-            
-            # Add nonreactive species (e.g. bath gases) to core first
-            # This is necessary so that the PDep algorithm can identify the bath gas
-            self.reactionModel.enlarge([spec for spec in self.initialSpecies if not spec.reactive])
-            # Then add remaining reactive species
+
             for spec in self.initialSpecies:
                 spec.generateThermoData(self.database, quantumMechanics=self.quantumMechanics)
                 spec.generateTransportData(self.database)
-
-            self.reactionModel.enlarge([spec for spec in self.initialSpecies if spec.reactive])
+                
+            # Add nonreactive species (e.g. bath gases) to core first
+            # This is necessary so that the PDep algorithm can identify the bath gas            
+            for spec in self.initialSpecies:
+                if not spec.reactive:
+                    self.reactionModel.enlarge(spec)
+            for spec in self.initialSpecies:
+                if spec.reactive:
+                    self.reactionModel.enlarge(spec)
             
             # Save a restart file if desired
             if self.saveRestartPeriod:
@@ -504,7 +507,8 @@ class RMG:
                 # These should be Species or Network objects
                 logging.info('')
                 objectsToEnlarge = list(set(objectsToEnlarge))
-                self.reactionModel.enlarge(objectsToEnlarge)
+                for objectToEnlarge in objectsToEnlarge:
+                    self.reactionModel.enlarge(objectToEnlarge)
 
             self.saveEverything()
 

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -779,14 +779,19 @@ class CoreEdgeReactionModel:
             self.updateUnimolecularReactionNetworks(database)
             logging.info('')
             
-        # Check new core reactions for Chemkin duplicates
+        # Check new core and edge reactions for Chemkin duplicates
+        # The same duplicate reaction gets brought into the core
+        # at the same time, so there is no danger in checking all of the edge.
         newCoreReactions = self.core.reactions[numOldCoreReactions:]
-        checkedCoreReactions = self.core.reactions[:numOldCoreReactions]
+        newEdgeReactions = self.edge.reactions[numOldEdgeReactions:]
+        checkedReactions = self.core.reactions[:numOldCoreReactions] + self.edge.reactions[:numOldEdgeReactions]
         from rmgpy.chemkin import markDuplicateReaction
         for rxn in newCoreReactions:
-            markDuplicateReaction(rxn,checkedCoreReactions)
-            checkedCoreReactions.append(rxn)
-        
+            markDuplicateReaction(rxn, checkedReactions)
+            checkedReactions.append(rxn)
+        for rxn in newEdgeReactions:
+            markDuplicateReaction(rxn, checkedReactions)
+            checkedReactions.append(rxn)
         self.printEnlargeSummary(
             newCoreSpecies=self.core.species[numOldCoreSpecies:],
             newCoreReactions=self.core.reactions[numOldCoreReactions:],

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -956,9 +956,9 @@ class CoreEdgeReactionModel:
         # uninformative strings, so here we replace them with much shorter ones
         if not self.verboseComments:
             # Only keep a short comment (to save memory)
-            if 'Exact' in kinetics.comment or 'Matched rule' in kinetics.comment:
+            if 'Exact' in kinetics.comment:
                 # Exact match of rate rule
-                kinetics.comment = 'Exact match found for rate rule ({0})'.format(','.join([g.label for g in reaction.template])) 
+                pass
             elif 'Matched reaction' in kinetics.comment:
                 # Stems from matching a reaction from a depository
                 pass

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -904,9 +904,9 @@ class CoreEdgeReactionModel:
             elif (entry is not None and rev_entry is not None 
                   and entry is rev_entry):
                 # Both forward and reverse have the same source and entry
-                # Use the one for which the kinetics is the forward kinetics
-                reason = "Both direction matched the same entry in {0}, which is defined in this direction.".format(reaction.family.label)
-                keepReverse = not isForward
+                # Use the one for which the kinetics is the forward kinetics          
+                keepReverse = G298 > 0 and isForward and rev_isForward
+                reason = "Both directions matched the same entry in {0}, but this direction is exergonic.".format(reaction.family.label)
             elif self.kineticsEstimator == 'group additivity' and (kinetics.comment.find("Fitted to 1 rate")>0
                   and not rev_kinetics.comment.find("Fitted to 1 rate")>0) :
                     # forward kinetics were fitted to only 1 rate, but reverse are hopefully better

--- a/rmgpy/rmg/model.py
+++ b/rmgpy/rmg/model.py
@@ -882,7 +882,6 @@ class CoreEdgeReactionModel:
         
         # Get the kinetics for the reaction
         kinetics, source, entry, isForward = reaction.family.getKinetics(reaction, template=reaction.template, degeneracy=reaction.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
-        
         # Get the enthalpy of reaction at 298 K
         H298 = reaction.getEnthalpyOfReaction(298)
         G298 = reaction.getFreeEnergyOfReaction(298)
@@ -893,21 +892,20 @@ class CoreEdgeReactionModel:
             
             # First get the kinetics for the other direction
             rev_kinetics, rev_source, rev_entry, rev_isForward = reaction.family.getKinetics(reaction.reverse, template=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator=self.kineticsEstimator, returnAllKinetics=False)
-
             # Now decide which direction's kinetics to keep
             keepReverse = False
-            if (source is not None and rev_source is None):
+            if (entry is not None and rev_entry is None):
                 # Only the forward has a source - use forward.
-                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(source.label)
-            elif (source is None and rev_source is not None):
+                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family.label)
+            elif (entry is None and rev_entry is not None):
                 # Only the reverse has a source - use reverse.
                 keepReverse = True
-                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(rev_source.label)
-            elif (source is not None and rev_source is not None 
+                reason = "This direction matched an entry in {0}, the other was just an estimate.".format(reaction.family.label)
+            elif (entry is not None and rev_entry is not None 
                   and entry is rev_entry):
                 # Both forward and reverse have the same source and entry
                 # Use the one for which the kinetics is the forward kinetics
-                reason = "Both direction matched the same entry in {0}, which is defined in this direction.".format(source.label)
+                reason = "Both direction matched the same entry in {0}, which is defined in this direction.".format(reaction.family.label)
                 keepReverse = not isForward
             elif self.kineticsEstimator == 'group additivity' and (kinetics.comment.find("Fitted to 1 rate")>0
                   and not rev_kinetics.comment.find("Fitted to 1 rate")>0) :


### PR DESCRIPTION
This pull request addresses https://github.com/GreenGroup/RMG-Py/issues/361.  The summary of changes:

* Make templates use semicolons so that it matches RMG-database format and is easier to search
* Remove duplicate kinetics estimation from rate rules function that was giving incorrect kinetics comments (saying that match is exact even when it is an average- basically it was showing that the node had data, but that data had been set by fillTreesbyAveragingUp)
* Make processNewReactions in rmgpy/rmg/model.py more deterministic.  Make it choose the exergonic direction in more cases so that we don't get different models when we put a reactant in vs. product, etc.
* Enlarge model with new core species individually to fix a logging bug as well as make it easier to see what RMG is doing through the log file.
* Removed duplicate hardcoding of reverse order templates for R_recombination family (kept working copy in getAllRules function in rmgpy/data/kinetics/rules.py). For example, now it treats rules (Cbrad;Hrad) and (Hrad;Cbrad) as duplicate entries of the same type in a family, so it will treat them the same way as other duplicate entries.

Benchmarking: full comparison of chemkin edge files that contained 453 reactions before and after these commit shows identical thermo/species/kinetics except for the following intentional changes:

    ! Reaction index: Chemkin #407; RMG #407
    ! Template reaction: H_Abstraction
    ! Exact match found for rate rule (Cd/H/NonDeC;Cd_rad/NonDeC)
    ! Kinetics were estimated in this direction instead of the reverse because:
    ! Both directions matched the same entry in H_Abstraction, but this direction is exergonic.
    ! dHrxn(298 K) = -19.66 kJ/mol, dGrxn(298 K) = -19.66 kJ/mol
    C6H6O(56)+C6H4O(228)=C4H6O(3)+C6H5O(39)             5.560e-03 4.340     4.500    

    ! Reaction index: Chemkin #268; RMG #268
    ! Template reaction: H_Abstraction
    ! Average of (Cd/H/NonDeC;Cd_rad/NonDeC + Cd/H/NonDeS;Cd_rad/NonDeC + Cd/H/NonDeC;Cd_rad/NonDeS + Cd/H/NonDeS;Cd_rad/NonDeS + Average of
    ! (Cd/H/Ct;Cd_rad/NonDeS + Cd/H/Cd;Cd_rad/NonDeS + Cd/H/CS;Cd_rad/NonDeS) + Average of (Cd/H/NonDeC;Cd_rad/Ct + Cd/H/NonDeC;Cd_rad/Cd +
    ! Cd/H/NonDeC;Cd_rad/CS) + Average of (Cd/H/NonDeS;Cd_rad/Ct + Cd/H/NonDeS;Cd_rad/Cd + Cd/H/NonDeS;Cd_rad/CS) + Average of (Cd/H/Ct;Cd_rad/Ct +
    ! Cd/H/Cd;Cd_rad/Ct + Cd/H/CS;Cd_rad/Ct + Cd/H/Ct;Cd_rad/Cd + Cd/H/Cd;Cd_rad/Cd + Cd/H/CS;Cd_rad/Cd + Cd/H/Ct;Cd_rad/CS + Cd/H/Cd;Cd_rad/CS +
    ! Cd/H/CS;Cd_rad/CS))
    ! Estimated using template (Cd_sec;Cd_sec_rad) for rate rule (Cd/H/OneDe;Cd_rad/NonDeC)
    ! Kinetics were estimated in this direction instead of the reverse because:
    ! Both directions are estimates, but this direction is exergonic.
    ! dHrxn(298 K) = -38.49 kJ/mol, dGrxn(298 K) = -37.12 kJ/mol
    C4H6O(3)+C4H6O(3)=C6H6O(56)+C6H4O(123)              5.781e-03 4.340     6.104 