### PR TITLE
fix rdKit conversion and subsequent Identifier generation for singlet carbene species

### DIFF
--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1502,6 +1502,7 @@ class Molecule(Graph):
         for index, atom in enumerate(self.vertices):
             rdAtom = Chem.rdchem.Atom(atom.element.symbol)
             rdAtom.SetNumRadicalElectrons(atom.radicalElectrons)
+            if atom.element.symbol == 'C' and atom.lonePairs == 1 and self.multiplicity == 1: rdAtom.SetNumRadicalElectrons(2)
             rdkitmol.AddAtom(rdAtom)
             rdAtomIndices[atom] = index
         

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1342,19 +1342,27 @@ class Molecule(Graph):
         obConversion.SetOptions('w', openbabel.OBConversion.OUTOPTIONS)
         return obConversion.WriteString(obmol).strip()
 
+    def createMultiplicityLayer(self):
+        """
+        Creates the string with the multiplicity information
+        that is appended to the InChI to create an augmented InChI.
+        
+        Only return a non-empty string when the multiplicity is >= 2.
+        """
+        
+        mult = self.multiplicity
+        return '/mult'+str(mult) if mult >= 2 else ''
+            
+        
     def toAugmentedInChI(self):
         """
-        Adds an extra layer to the InChI denoting the number of unpaired electrons in case
-        more than 1 ( >= 2) unpaired electrons are present in the molecule.
+        Adds an extra layer to the InChI denoting the multiplicity
+        of the molecule.
         """
         inchi = self.toInChI()
         
-        radicalNumber = sum([i.radicalElectrons for i in self.atoms])
+        return inchi + self.createMultiplicityLayer()
         
-        if radicalNumber >= 2:
-            return inchi+'/mult'+str(radicalNumber+1)
-        else:
-            return inchi
     
     def toInChIKey(self):
         """
@@ -1390,17 +1398,14 @@ class Molecule(Graph):
     
     def toAugmentedInChIKey(self):
         """
-        Adds an extra layer to the InChIKey denoting the number of unpaired electrons in case
-        more than 1 ( >= 2) unpaired electrons are present in the molecule.
+        Adds an extra layer to the InChIKey denoting the multiplicity
+        of the molecule.
+
         """
         key = self.toInChIKey()
         
-        radicalNumber = sum([i.radicalElectrons for i in self.atoms])
-        
-        if radicalNumber >= 2:
-            return key+'mult'+str(radicalNumber+1)
-        else:
-            return key
+        return key + self.createMultiplicityLayer()
+    
 
     def toSMARTS(self):
         """

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -1347,21 +1347,22 @@ class Molecule(Graph):
         Creates the string with the multiplicity information
         that is appended to the InChI to create an augmented InChI.
         
-        Only return a non-empty string when the multiplicity is >= 2.
         """
         
         mult = self.multiplicity
-        return '/mult'+str(mult) if mult >= 2 else ''
+        return ''.join(['mult', str(mult)])
             
         
     def toAugmentedInChI(self):
         """
         Adds an extra layer to the InChI denoting the multiplicity
         of the molecule.
+        
+        Separate layer with a forward slash character.
         """
         inchi = self.toInChI()
         
-        return inchi + self.createMultiplicityLayer()
+        return '/'.join([inchi , self.createMultiplicityLayer()])
         
     
     def toInChIKey(self):
@@ -1401,10 +1402,12 @@ class Molecule(Graph):
         Adds an extra layer to the InChIKey denoting the multiplicity
         of the molecule.
 
+        Simply append the multiplicity string, do not separate by a
+        character like forward slash.
         """
         key = self.toInChIKey()
         
-        return key + self.createMultiplicityLayer()
+        return ''.join([key , self.createMultiplicityLayer()])
     
 
     def toSMARTS(self):

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1039,6 +1039,41 @@ class TestMolecule(unittest.TestCase):
         """
         self.assertEqual(Molecule().fromSMILES('C#C').countInternalRotors(), 0)
     
+    def testCarbeneIdentifiers(self):
+        """
+        Test that singlet carbene molecules, bearing an electron pair rather than unpaired electrons
+        are correctly converted into rdkit molecules and identifiers.
+        """
+        
+
+        ch2_t = '''
+        multiplicity 3
+        1 C u2 p0 c0 {2,S} {3,S}
+        2 H u0 p0 c0 {1,S}
+        3 H u0 p0 c0 {1,S}
+        '''
+        
+        mol = Molecule().fromAdjacencyList(ch2_t)
+    
+        self.assertEqual( mol.toAugmentedInChI(), 'InChI=1S/CH2/h1H2/mult3')
+        self.assertEqual( mol.toSMILES(), '[CH2]')
+        
+
+        ch2_s = '''
+        multiplicity 1
+        1 C u0 p1 c0 {2,S} {3,S}
+        2 H u0 p0 c0 {1,S}
+        3 H u0 p0 c0 {1,S}
+        '''
+        
+        mol = Molecule().fromAdjacencyList(ch2_s)
+        self.assertEqual( mol.toAugmentedInChI(), 'InChI=1S/CH2/h1H2/mult1')
+        self.assertEqual( mol.toSMILES(), '[CH2]')
+        
+        
+        
+        
+        
     @work_in_progress
     def testCountInternalRotorsDimethylAcetylene(self):
         """


### PR DESCRIPTION
- convert the lone pair electrons into 2 unpaired electrons for singlet carbene atoms when converting to rdKit Molecules
- append a multiplicity layer in the augmented identifiers regardless of the multiplicity of the molecule
- use the multiplicity attribute of the Molecule rather than the radical atom count for the multiplicity layer
- use 1 method to create this layer and call it in the callers.
- adds a test in moleculeTest