### PR TITLE
Symmetry contribution for radicals

### DIFF
--- a/diffModels.py
+++ b/diffModels.py
@@ -237,7 +237,7 @@ if __name__ == '__main__':
     for spec1, spec2 in commonSpecies:
         print '    {0!s}'.format(spec1)
         if spec1.thermo and spec2.thermo:
-            spec1.molecule[0].calculateSymmetryNumber()
+            spec1.molecule[0].getSymmetryNumber()
             print '        {0:7.2f} {1:7.2f} {2:7.2f} {3:7.2f} {4:7.2f} {5:7.2f} {6:7.2f} {7:7.2f} {8:7.2f}'.format( 
                 spec1.thermo.getEnthalpy(300) / 4184.,
                 spec1.thermo.getEntropy(300) / 4.184,

--- a/rmgpy/data/thermo.py
+++ b/rmgpy/data/thermo.py
@@ -867,8 +867,7 @@ class ThermoDatabase(object):
         assert thermoData is not None, "Thermo data of saturated {0} of molecule {1} is None!".format(saturatedStruct, molecule)
         
         # Correct entropy for symmetry number of radical structure
-        molecule.calculateSymmetryNumber()
-        thermoData.S298.value_si -= constants.R * math.log(molecule.symmetryNumber)
+        thermoData.S298.value_si -= constants.R * math.log(molecule.getSymmetryNumber())
         
         # For each radical site, get radical correction
         # Only one radical site should be considered at a time; all others
@@ -926,8 +925,7 @@ class ThermoDatabase(object):
             thermoData = self.estimateThermoViaGroupAdditivityForSaturatedStructWithoutSymmetryCorrection(molecule)
 
         # Correct entropy for symmetry number
-        molecule.calculateSymmetryNumber()
-        thermoData.S298.value_si -= constants.R * math.log(molecule.symmetryNumber)
+        thermoData.S298.value_si -= constants.R * math.log(molecule.getSymmetryNumber())
 
         return thermoData
 

--- a/rmgpy/data/thermoTest.py
+++ b/rmgpy/data/thermoTest.py
@@ -84,6 +84,28 @@ class TestThermoDatabase(unittest.TestCase):
             for T, Cp in zip(self.Tlist, Cplist):
                 self.assertAlmostEqual(Cp, thermoData.getHeatCapacity(T) / 4.184, places=1, msg="Cp{1} error for {0}".format(smiles,T))
 
+    def testSymmetryContributionRadicals(self):
+        """
+        Test that the symmetry contribution is correctly added for radicals
+        estimated via the HBI method. 
+        """
+        from rmgpy.data.rmg import RMGDatabase
+        from rmgpy.rmg.main import RMG
+        from rmgpy.rmg.model import Species
+        
+        rmg = RMG()
+        database = RMGDatabase()
+        database.load(os.path.join(settings['database.directory']), kineticsFamilies='none')
+        
+        spc = Species(molecule=[Molecule().fromSMILES('[CH3]')])
+        
+        thermoData_lib = database.thermo.getThermoDataFromLibraries(spc)[0]
+        
+        thermoData_ga = database.thermo.getThermoDataFromGroups(spc)
+        
+        self.assertAlmostEqual(thermoData_lib.getEntropy(298.), thermoData_ga.getEntropy(298.), 0)
+
+        
     @work_in_progress
     def testSymmetryNumberGeneration(self):
         """

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -214,3 +214,4 @@ cdef class Molecule(Graph):
     cpdef findAllDelocalizationPathsN5dd_N5ts(self, Atom atom1)
 
     cpdef int calculateSymmetryNumber(self) except -1
+    

--- a/rmgpy/molecule/molecule.pxd
+++ b/rmgpy/molecule/molecule.pxd
@@ -43,6 +43,7 @@ cdef class Atom(Vertex):
     cdef public AtomType atomType
     cdef public numpy.ndarray coords
     cdef public short lonePairs
+
     
     cpdef bint equivalent(self, Vertex other) except -2
 
@@ -106,7 +107,8 @@ cdef class Molecule(Graph):
     cdef public object rdMol
     cdef public int rdMolConfId
     cdef str _fingerprint
-        
+    cdef public dict props
+    
     cpdef str getFingerprint(self)
     
     cpdef addAtom(self, Atom atom)

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -602,7 +602,7 @@ class Molecule(Graph):
     `InChI` string representing the molecular structure.
     """
 
-    def __init__(self, atoms=None, symmetry=-1, multiplicity=-187, SMILES='', InChI='', SMARTS=''):
+    def __init__(self, atoms=None, symmetry=-1, multiplicity=-187, props=None ,SMILES='', InChI='', SMARTS=''):
         Graph.__init__(self, atoms)
         self.symmetryNumber = symmetry
         self.multiplicity = multiplicity
@@ -610,6 +610,7 @@ class Molecule(Graph):
         if SMILES != '': self.fromSMILES(SMILES)
         elif InChI != '': self.fromInChI(InChI)
         elif SMARTS != '': self.fromSMARTS(SMARTS)
+        self.props = props or {}
         if multiplicity != -187:  # it was set explicitly, so re-set it (fromSMILES etc may have changed it)
             self.multiplicity = multiplicity
     
@@ -633,7 +634,7 @@ class Molecule(Graph):
         """
         A helper function used when pickling an object.
         """
-        return (Molecule, (self.vertices, self.symmetryNumber, self.multiplicity))
+        return (Molecule, (self.vertices, self.symmetryNumber, self.multiplicity, self.props))
 
     def __getAtoms(self): return self.vertices
     def __setAtoms(self, atoms): self.vertices = atoms

--- a/rmgpy/molecule/molecule.py
+++ b/rmgpy/molecule/molecule.py
@@ -602,7 +602,7 @@ class Molecule(Graph):
     `InChI` string representing the molecular structure.
     """
 
-    def __init__(self, atoms=None, symmetry=1, multiplicity=-187, SMILES='', InChI='', SMARTS=''):
+    def __init__(self, atoms=None, symmetry=-1, multiplicity=-187, SMILES='', InChI='', SMARTS=''):
         Graph.__init__(self, atoms)
         self.symmetryNumber = symmetry
         self.multiplicity = multiplicity
@@ -1648,6 +1648,17 @@ class Molecule(Graph):
             
             return self.calculateCp0() + (Nvib + 0.5 * Nrotors) * constants.R
 
+    def getSymmetryNumber(self):
+        """
+        Returns the symmetry number of Molecule.
+        First checks whether the value is stored as an attribute of Molecule.
+        If not, it calls the calculateSymmetryNumber method. 
+        """
+        if self.symmetryNumber == -1:
+            self.calculateSymmetryNumber()
+        return self.symmetryNumber
+        
+        
     def calculateSymmetryNumber(self):
         """
         Return the symmetry number for the structure. The symmetry number

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1071,8 +1071,17 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual( mol.toSMILES(), '[CH2]')
         
         
+    def testGetSymmetryNumber(self):
+        """
+        Test that the symmetry number getter works properly
+        """
         
+        mol = Molecule().fromSMILES('C')
         
+        self.assertEquals(12, mol.getSymmetryNumber())
+        
+        empty = Molecule()
+        self.assertEquals(1, empty.getSymmetryNumber())
         
     @work_in_progress
     def testCountInternalRotorsDimethylAcetylene(self):

--- a/rmgpy/molecule/moleculeTest.py
+++ b/rmgpy/molecule/moleculeTest.py
@@ -1082,6 +1082,29 @@ class TestMolecule(unittest.TestCase):
         
         empty = Molecule()
         self.assertEquals(1, empty.getSymmetryNumber())
+    
+    def testMoleculeProps(self):
+        """
+        Test a key-value pair is added to the props attribute of Molecule.
+        """
+        self.molecule[0].props['foo'] = 'bar'
+        self.assertIsInstance(self.molecule[0].props, dict)
+        self.assertEquals(self.molecule[0].props['foo'], 'bar')
+        
+    def testMoleculeProps_object_attribute(self):
+        """
+        Test that Molecule's props dictionaries are independent of each other.
+        
+        Create a test in which is checked whether props is an object attribute rather
+        than a class attribute
+        """
+        spc2 = Molecule()
+        self.molecule[0].props['foo'] = 'bar'
+        spc3 = Molecule()
+        spc3.props['foo'] = 'bla'
+        self.assertEquals(self.molecule[0].props['foo'], 'bar')
+        self.assertDictEqual(spc2.props, {})
+        self.assertDictEqual(spc3.props, {'foo': 'bla'})
         
     @work_in_progress
     def testCountInternalRotorsDimethylAcetylene(self):

--- a/rmgpy/species.py
+++ b/rmgpy/species.py
@@ -361,7 +361,7 @@ class Species(object):
         requires additional calculateSymmetryNumber calls.
         """
         cython.declare(symmetryNumber=cython.int)
-        symmetryNumber = numpy.max([mol.calculateSymmetryNumber() for mol in self.molecule])
+        symmetryNumber = numpy.max([mol.getSymmetryNumber() for mol in self.molecule])
         return symmetryNumber
         
     def calculateCp0(self):


### PR DESCRIPTION
- remove the symmetry contribution for saturated species if the thermo originates from thermo libraries, or QMTP
- check if pre-computed symmetry number exists before calculating it again