### PR TITLE
Fix issues with solvation thermo for C#O.

### DIFF
--- a/rmgpy/data/solvation.py
+++ b/rmgpy/data/solvation.py
@@ -724,25 +724,25 @@ class SolvationDatabase(object):
                     if bond.order == 'T': sumBondOrders += 3
                     if bond.order == 'B': sumBondOrders += 1.5 # We should always have 2 'B' bonds (but what about Cbf?)
                 if atomTypes['Val4'] in atom.atomType.generic: # Carbon, Silicon
-                    while(atom.radicalElectrons + charge + sumBondOrders != 4):
+                    while(atom.radicalElectrons + charge + sumBondOrders < 4):
                         atom.decrementLonePairs()
                         atom.incrementRadical()
                         atom.incrementRadical()
                         addedToPairs[atom] += 1
                 if atomTypes['Val5'] in atom.atomType.generic: # Nitrogen
-                    while(atom.radicalElectrons + charge + sumBondOrders != 3):
+                    while(atom.radicalElectrons + charge + sumBondOrders < 3):
                         atom.decrementLonePairs()
                         atom.incrementRadical()
                         atom.incrementRadical()
                         addedToPairs[atom] += 1
                 if atomTypes['Val6'] in atom.atomType.generic: # Oxygen, sulfur
-                    while(atom.radicalElectrons + charge + sumBondOrders != 2):
+                    while(atom.radicalElectrons + charge + sumBondOrders < 2):
                         atom.decrementLonePairs()
                         atom.incrementRadical()
                         atom.incrementRadical()
                         addedToPairs[atom] += 1
                 if atomTypes['Val7'] in atom.atomType.generic: # Chlorine
-                    while(atom.radicalElectrons + charge + sumBondOrders != 1):
+                    while(atom.radicalElectrons + charge + sumBondOrders < 1):
                         atom.decrementLonePairs()
                         atom.incrementRadical()
                         atom.incrementRadical()

--- a/rmgpy/data/solvationTest.py
+++ b/rmgpy/data/solvationTest.py
@@ -133,7 +133,18 @@ multiplicity 1
         species = Species(molecule=[molecule])
         soluteData = self.database.getSoluteDataFromGroups(species)
         self.assertTrue(soluteData is not None)
-        
+
+    def testSoluteDataGenerationCO(self):
+        "Test that we can obtain solute parameters via group additivity for CO."        
+        molecule=Molecule().fromAdjacencyList(
+"""
+1  C u0 p1 c-1 {2,T}
+2  O u0 p1 c+1 {1,T}
+""")
+        species = Species(molecule=[molecule])
+        soluteData = self.database.getSoluteDataFromGroups(species)
+        self.assertTrue(soluteData is not None)
+    
     def testRadicalandLonePairGeneration(self):
         """
         Test we can obtain solute parameters via group additivity for a molecule with both lone 


### PR DESCRIPTION
This addresses #367, and goes along with a corresponding database fix.

Added a new unit test for C#O and changed how we change lone pairs into bi-radicals to saturate.