### PR TITLE
Fix the way LogicOR groups are handled in descending kinetics tree

### DIFF
--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -871,13 +871,15 @@ class Database:
         atom in `structure`.
         
         Matching to structure is more strict than to node.  All labels in structure must 
-        be found in node.  However the reverse is not true.
+        be found in node.  However the reverse is not true, unless `strict` is set to True.
         
         Usage: node = either an Entry or a key in the self.entries dictionary which has
                       a Group or LogicNode as its Entry.item
                structure = a Group or a Molecule
                atoms = dictionary of {label: atom} in the structure.  A possible dictionary
                        is the one produced by structure.getLabeledAtoms()
+               strict = if set to True, ensures that all the node's atomLabels are matched by
+                        in the structure.
         """
         if isinstance(node, str): node = self.entries[node]
         group = node.item
@@ -946,7 +948,8 @@ class Database:
         Returns None if there is no matching root.
         
         Set strict to ``True`` if all labels in final matched node must match that of the
-        structure.
+        structure.  This is used in kinetics groups to find the correct reaction template, but
+        not generally used in other GAVs due to species generally not being prelabeled.
         """
 
         if root is None:
@@ -1012,6 +1015,9 @@ class LogicOr(LogicNode):
     def matchToStructure(self,database,structure,atoms,strict=False):
         """
         Does this node in the given database match the given structure with the labeled atoms?
+        
+        Setting `strict` to True makes enforces matching of atomLabels in the structure to every
+        atomLabel in the node.
         """
         for node in self.components:
             if isinstance(node,LogicNode):
@@ -1058,6 +1064,9 @@ class LogicAnd(LogicNode):
     def matchToStructure(self,database,structure,atoms,strict=False):
         """
         Does this node in the given database match the given structure with the labeled atoms?
+        
+        Setting `strict` to True makes enforces matching of atomLabels in the structure to every
+        atomLabel in the node.
         """
         for node in self.components:
             if isinstance(node,LogicNode):

--- a/rmgpy/data/base.py
+++ b/rmgpy/data/base.py
@@ -859,7 +859,7 @@ class Database:
         elif isinstance(parentNode.item,LogicOr):
             return childNode.label in parentNode.item.components
 
-    def matchNodeToStructure(self, node, structure, atoms):
+    def matchNodeToStructure(self, node, structure, atoms, strict=False):
         """
         Return :data:`True` if the `structure` centered at `atom` matches the
         structure at `node` in the dictionary. The structure at `node` should
@@ -882,7 +882,7 @@ class Database:
         if isinstance(node, str): node = self.entries[node]
         group = node.item
         if isinstance(group, LogicNode):
-            return group.matchToStructure(self, structure, atoms)
+            return group.matchToStructure(self, structure, atoms, strict)
         else:
             # try to pair up labeled atoms
             centers = group.getLabeledAtoms()
@@ -891,8 +891,10 @@ class Database:
                 # Make sure the labels are in both group and structure.
                 if label not in atoms:
                     logging.log(0, "Label {0} is in group {1} but not in structure".format(label, node))
+                    if strict:
+                        # structure must match all labeled atoms in node if strict is set to True
+                        return False 
                     continue # with the next label - ring structures might not have all labeled atoms
-                    # return False # force it to have all the labeled atoms
                 center = centers[label]
                 atom = atoms[label]
                 # Make sure labels actually point to atoms.
@@ -934,7 +936,7 @@ class Database:
                 structure.atoms.append(atom)
             return result
 
-    def descendTree(self, structure, atoms, root=None):
+    def descendTree(self, structure, atoms, root=None, strict=False):
         """
         Descend the tree in search of the functional group node that best
         matches the local structure around `atoms` in `structure`.
@@ -942,24 +944,27 @@ class Database:
         If root=None then uses the first matching top node.
 
         Returns None if there is no matching root.
+        
+        Set strict to ``True`` if all labels in final matched node must match that of the
+        structure.
         """
 
         if root is None:
             for root in self.top:
-                if self.matchNodeToStructure(root, structure, atoms):
+                if self.matchNodeToStructure(root, structure, atoms, strict):
                     break # We've found a matching root
             else: # didn't break - matched no top nodes
                 return None
-        elif not self.matchNodeToStructure(root, structure, atoms):
+        elif not self.matchNodeToStructure(root, structure, atoms, strict):
             return None
         
         next = []
         for child in root.children:
-            if self.matchNodeToStructure(child, structure, atoms):
+            if self.matchNodeToStructure(child, structure, atoms, strict):
                 next.append(child)
 
         if len(next) == 1:
-            return self.descendTree(structure, atoms, next[0])
+            return self.descendTree(structure, atoms, next[0], strict)
         elif len(next) == 0:
             if len(root.children) > 0 and root.children[-1].label.startswith('Others-'):
                 return root.children[-1]
@@ -967,7 +972,7 @@ class Database:
                 return root
         else:
             #logging.warning('For {0}, a node {1} with overlapping children {2} was encountered in tree with top level nodes {3}. Assuming the first match is the better one.'.format(structure, root, next, self.top))
-            return self.descendTree(structure, atoms, next[0])
+            return self.descendTree(structure, atoms, next[0], strict)
 
 ################################################################################
 
@@ -1004,15 +1009,15 @@ class LogicOr(LogicNode):
 
     symbol = "OR"
 
-    def matchToStructure(self,database,structure,atoms):
+    def matchToStructure(self,database,structure,atoms,strict=False):
         """
         Does this node in the given database match the given structure with the labeled atoms?
         """
         for node in self.components:
             if isinstance(node,LogicNode):
-                match = node.matchToStructure(database,structure,atoms)
+                match = node.matchToStructure(database, structure, atoms, strict)
             else:
-                match = database.matchNodeToStructure(node, structure, atoms)
+                match = database.matchNodeToStructure(node, structure, atoms, strict)
             if match:
                 return True != self.invert
         return False != self.invert
@@ -1050,15 +1055,15 @@ class LogicAnd(LogicNode):
 
     symbol = "AND"
 
-    def matchToStructure(self,database,structure,atoms):
+    def matchToStructure(self,database,structure,atoms,strict=False):
         """
         Does this node in the given database match the given structure with the labeled atoms?
         """
         for node in self.components:
             if isinstance(node,LogicNode):
-                match = node.matchToStructure(database,structure,atoms)
+                match = node.matchToStructure(database, structure, atoms, strict)
             else:
-                match = database.matchNodeToStructure(node, structure, atoms)
+                match = database.matchNodeToStructure(node, structure, atoms, strict)
             if not match:
                 return False != self.invert
         return True != self.invert

--- a/rmgpy/data/kinetics/groups.py
+++ b/rmgpy/data/kinetics/groups.py
@@ -118,25 +118,23 @@ class KineticsGroups(Database):
             # entry is a top-level node that should be matched
             group = entry.item
 
-            # To sort out "union" groups, descend to the first child that's not a logical node
-            # ...but this child may not match the structure.
-            # eg. an R3 ring node will not match an R4 ring structure.
-            # (but at least the first such child will contain fewest labels - we hope)
-            if isinstance(entry.item, LogicNode):
-                group = entry.item.getPossibleStructures(self.entries)[0]
-
-            atomList = group.getLabeledAtoms() # list of atom labels in highest non-union node
+            # Identify the atom labels in a group if it is not a logical node
+            atomList = []
+            if not isinstance(entry.item, LogicNode):
+                atomList = group.getLabeledAtoms()
 
             for reactant in reaction.reactants:
                 if isinstance(reactant, Species):
                     reactant = reactant.molecule[0]
                 # Match labeled atoms
-                # Check this reactant has each of the atom labels in this group
+                # Check that this reactant has each of the atom labels in this group.  If it is a LogicNode, the atomList is empty and 
+                # it will proceed directly to the descendTree step.
                 if not all([reactant.containsLabeledAtom(label) for label in atomList]):
                     continue # don't try to match this structure - the atoms aren't there!
                 # Match structures
                 atoms = reactant.getLabeledAtoms()
-                matched_node = self.descendTree(reactant, atoms, root=entry)
+                # Descend the tree, making sure to match atomlabels exactly using strict = True
+                matched_node = self.descendTree(reactant, atoms, root=entry, strict=True)
                 if matched_node is not None:
                     template.append(matched_node)
                 #else:


### PR DESCRIPTION
This pull request addresses https://github.com/GreenGroup/RMG-Py/issues/381

Change the way descendTree works, allowing an optional argument for 'strict' matching, in other words, requiring that groups and the molecules that match them completely match all atom labels.  Our previous check in generate reactions is not very robust.  I decided to alter the base function rather than implement lines in the generate reactions section.

We use strict atom label matching in finding the correct kinetic groups to associate
with a reaction and its reaction template.  However, the previous method used for LogicOr groups
was flawed.  It found the very first child node of an LogicOR group and used its atomLabels
to match the reactant.  However, sometimes the LogicOR group contained children that had
different atomLabels.  This resulted in some correct matches being thrown out.

By adding a ``strict`` argument to the descendTree function, the matchNodeToStructure, and
matchToStructure functions, we can be sure that full atom label matching takes place.  Note
that this is currently used primarily for kinetic groups and is not implemented for other
functions such as thermo estimation.